### PR TITLE
Change postBuild

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,17 +1,14 @@
 name: ferretmagic
 channels:
   - conda-forge
-  - r
 dependencies:
   - python=3.7
   - jupyter=1.0.0
   - notebook=6.0.1
   - numpy=1.17.3
   - pandas=0.25.3
-  - bokeh=1.4.0
   - pyferret=7.5.0
   - ferret_datasets=7.4
-  - rpy2=3.1.0
   - pip=19.3.1
   - pip:
     - ipywidgets==7.5.1

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,11 +8,21 @@ jupyter nbextension enable --py widgetsnbextension --sys-prefix
 #==================================================
 git clone https://github.com/PBrockmann/fast
 
+#==================================================
 pyferretActivate=/srv/conda/envs/notebook/etc/conda/activate.d/pyferret-activate.sh
 
+#==================================================
+# Modify env variables to get all fast materials (scripts, palettes)
 echo '' >> $pyferretActivate
 echo '=========================================' >> $pyferretActivate
 echo 'export FER_DATA=". $FER_DATA $HOME/fast"' >> $pyferretActivate
 echo 'export FER_GO=". $FER_GO $HOME/fast"' >> $pyferretActivate
 echo 'export FER_PALETTE=". /$FER_PALETTE $HOME/fast"' >> $pyferretActivate
 echo 'export PATH="$FER_DIR/bin:$HOME/fast:$PATH"' >> $pyferretActivate
+
+#==================================================
+# Add directories specific to this repository
+echo '' >> $pyferretActivate
+echo '=========================================' >> $pyferretActivate
+echo 'export FER_GO=". $FER_GO $HOME/files/GO"' >> $pyferretActivate
+echo 'export FER_PALETTE=". /$FER_PALETTE $HOME/files/Palettes"' >> $pyferretActivate

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -17,7 +17,7 @@ echo '' >> $pyferretActivate
 echo '=========================================' >> $pyferretActivate
 echo 'export FER_DATA=". $FER_DATA $HOME/fast"' >> $pyferretActivate
 echo 'export FER_GO=". $FER_GO $HOME/fast"' >> $pyferretActivate
-echo 'export FER_PALETTE=". /$FER_PALETTE $HOME/fast"' >> $pyferretActivate
+echo 'export FER_PALETTE=". $FER_PALETTE $HOME/fast"' >> $pyferretActivate
 echo 'export PATH="$FER_DIR/bin:$HOME/fast:$PATH"' >> $pyferretActivate
 
 #==================================================
@@ -25,4 +25,4 @@ echo 'export PATH="$FER_DIR/bin:$HOME/fast:$PATH"' >> $pyferretActivate
 echo '' >> $pyferretActivate
 echo '=========================================' >> $pyferretActivate
 echo 'export FER_GO=". $FER_GO $HOME/files/GO"' >> $pyferretActivate
-echo 'export FER_PALETTE=". /$FER_PALETTE $HOME/files/Palettes"' >> $pyferretActivate
+echo 'export FER_PALETTE=". $FER_PALETTE $HOME/files/Palettes"' >> $pyferretActivate


### PR DESCRIPTION
Have changed postBuild to add your go and palette files.
Have removed dependancies to r (not used in your case).

I have been able to draw all figure except:

-  Figure 8 where I get : 

`
yes? plot/set/vlim=0:14/hlim=1:12/grat=(dash,color=7)/key=title/thick=2 var7,var1,var4
**ERROR: inconsistent sizes of data regions: X axis 
PRECIP[D=1,GT=MYTIME@ASN] has 4 points (I=28:31)
expression has 55 points (I=619:673)
`

- Figure 11cd (same for Figure 12, Figure 15)

`yes? fill/pal=SCP_broc_25/k=1/lev=(-inf)(-3,3,0.25)(inf)/nolab sal_cm5a[gx=sal_woa,l=@ave]-sal_woa[l=@ave,d=3];go land
**ERROR: file undefined or not found: unable to open "SCP_broc_25.spk" to set plot colors or pattern. 
`
Change palette name (ie without my name 'broc' please).

- Figure Left and Right
`**TMAP ERR: non-existent or not on line ORCA2.3_grid.nc `
`**TMAP ERR: non-existent or not on line 90Ma_grid.nc`

Also noticed:
- too big labels for axis plot.
![image](https://user-images.githubusercontent.com/5402758/68877199-f97a6380-0705-11ea-9e2b-da00a56ef77e.png)
Perhaps use of font=arial would be nicer.
- Use of `set window/aspect=0.65` that is useless since you can produced a figure with a specified size with -s option for exemple `%%ferret -q -s 600,600`

And last, a proper acknowledging for ferret and pyferret work.
https://ferretop.pmel.noaa.gov/Ferret/documentation/acknowledging-ferret
`The author(s) wish to acknowledge use of the Ferret program for analysis and graphics in this paper. Ferret is a product of NOAA's Pacific Marine Environmental Laboratory. (Information is available at http://ferret.pmel.noaa.gov/Ferret/)`

